### PR TITLE
Test/83 add test registration email

### DIFF
--- a/lib/screens/registration_email_screen.dart
+++ b/lib/screens/registration_email_screen.dart
@@ -5,8 +5,20 @@ import '../services/registration_flow_service.dart';
 import '../utils/registration_response_parsing.dart';
 import '../widgets/loading_widget.dart';
 
+typedef SendRegistrationOtpRequest =
+    Future<RegistrationApiResult> Function(String email);
+
 class RegistrationEmailScreen extends StatefulWidget {
-  const RegistrationEmailScreen({super.key});
+  final SendRegistrationOtpRequest? sendRegistrationOtpRequest;
+  final RegistrationFlowService? flowService;
+  final LoadingService? loadingService;
+
+  const RegistrationEmailScreen({
+    super.key,
+    this.sendRegistrationOtpRequest,
+    this.flowService,
+    this.loadingService,
+  });
 
   @override
   State<RegistrationEmailScreen> createState() =>
@@ -17,8 +29,8 @@ class _RegistrationEmailScreenState extends State<RegistrationEmailScreen> {
   final _formKey = GlobalKey<FormState>();
   final _emailController = TextEditingController();
   final _apiService = ApiService();
-  final _loadingService = LoadingService();
-  final _flow = RegistrationFlowService();
+  late final LoadingService _loadingService;
+  late final RegistrationFlowService _flow;
   late final VoidCallback _emailListener;
 
   static const String _loadingOperation = 'registration_send_otp';
@@ -29,6 +41,8 @@ class _RegistrationEmailScreenState extends State<RegistrationEmailScreen> {
   @override
   void initState() {
     super.initState();
+    _loadingService = widget.loadingService ?? LoadingService();
+    _flow = widget.flowService ?? RegistrationFlowService();
     _emailController.text = _flow.email;
     _emailListener = () {
       _flow.setEmail(_emailController.text);
@@ -53,7 +67,9 @@ class _RegistrationEmailScreenState extends State<RegistrationEmailScreen> {
 
     try {
       final email = _emailController.text.trim();
-      final result = await _apiService.sendRegistrationOtp(email);
+      final sendRegistrationOtp =
+          widget.sendRegistrationOtpRequest ?? _apiService.sendRegistrationOtp;
+      final result = await sendRegistrationOtp(email);
 
       if (!mounted) {
         return;

--- a/lib/screens/registration_email_screen.dart
+++ b/lib/screens/registration_email_screen.dart
@@ -128,6 +128,7 @@ class _RegistrationEmailScreenState extends State<RegistrationEmailScreen> {
                 ),
                 const SizedBox(height: 24),
                 TextFormField(
+                  key: const Key('email_input'),
                   controller: _emailController,
                   keyboardType: TextInputType.emailAddress,
                   autofillHints: const [AutofillHints.email],
@@ -156,6 +157,7 @@ class _RegistrationEmailScreenState extends State<RegistrationEmailScreen> {
                 SizedBox(
                   height: 50,
                   child: ElevatedButton(
+                    key: const Key('send_otp_button'),
                     onPressed: _loadingService.isLoading(_loadingOperation)
                         ? null
                         : _submit,

--- a/test/screens/registration_email_screen_test.dart
+++ b/test/screens/registration_email_screen_test.dart
@@ -61,6 +61,45 @@ void main() {
       expect(sentEmails, ['new-user@example.com']);
     });
 
+    testWidgets('クライアント側バリデーションNG時は送信処理を呼ばない', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        sendRegistrationOtp: (email) async {
+          sentEmails.add(email);
+          return const RegistrationApiResult(
+            statusCode: 200,
+            status: RegistrationApiStatus.success,
+            message: 'ok',
+            data: {'retry_after': 60},
+          );
+        },
+      );
+
+      await tester.enterText(find.byKey(const Key('email_input')), '');
+      await tester.tap(find.byKey(const Key('send_otp_button')));
+      await tester.pumpAndSettle();
+      expect(find.text('メールアドレスを入力してください'), findsOneWidget);
+      expect(sentEmails, isEmpty);
+      expect(flow.currentStep, RegistrationStep.emailInput);
+
+      await tester.enterText(find.byKey(const Key('email_input')), '   ');
+      await tester.tap(find.byKey(const Key('send_otp_button')));
+      await tester.pumpAndSettle();
+      expect(find.text('メールアドレスを入力してください'), findsOneWidget);
+      expect(sentEmails, isEmpty);
+      expect(flow.currentStep, RegistrationStep.emailInput);
+
+      await tester.enterText(
+        find.byKey(const Key('email_input')),
+        'invalid-email',
+      );
+      await tester.tap(find.byKey(const Key('send_otp_button')));
+      await tester.pumpAndSettle();
+      expect(find.text('有効なメールアドレスを入力してください'), findsOneWidget);
+      expect(sentEmails, isEmpty);
+      expect(flow.currentStep, RegistrationStep.emailInput);
+    });
+
     testWidgets('成功時に OTP画面へ遷移する', (WidgetTester tester) async {
       await pumpScreen(
         tester,

--- a/test/screens/registration_email_screen_test.dart
+++ b/test/screens/registration_email_screen_test.dart
@@ -52,10 +52,10 @@ void main() {
       );
 
       await tester.enterText(
-        find.byType(TextFormField),
+        find.byKey(const Key('email_input')),
         '  new-user@example.com  ',
       );
-      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.tap(find.byKey(const Key('send_otp_button')));
       await tester.pumpAndSettle();
 
       expect(sentEmails, ['new-user@example.com']);
@@ -72,8 +72,14 @@ void main() {
         ),
       );
 
-      await tester.enterText(find.byType(TextFormField), 'next@example.com');
-      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      expect(flow.currentStep, RegistrationStep.emailInput);
+      expect(flow.email, isEmpty);
+
+      await tester.enterText(
+        find.byKey(const Key('email_input')),
+        'next@example.com',
+      );
+      await tester.tap(find.byKey(const Key('send_otp_button')));
       await tester.pumpAndSettle();
 
       expect(flow.currentStep, RegistrationStep.otpVerification);
@@ -91,8 +97,11 @@ void main() {
         ),
       );
 
-      await tester.enterText(find.byType(TextFormField), 'dup@example.com');
-      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.enterText(
+        find.byKey(const Key('email_input')),
+        'dup@example.com',
+      );
+      await tester.tap(find.byKey(const Key('send_otp_button')));
       await tester.pumpAndSettle();
 
       expect(
@@ -112,8 +121,11 @@ void main() {
         ),
       );
 
-      await tester.enterText(find.byType(TextFormField), 'bad@example.com');
-      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.enterText(
+        find.byKey(const Key('email_input')),
+        'bad@example.com',
+      );
+      await tester.tap(find.byKey(const Key('send_otp_button')));
       await tester.pumpAndSettle();
 
       expect(find.text('メールアドレスの形式を確認して、もう一度入力してください。'), findsOneWidget);
@@ -130,8 +142,11 @@ void main() {
         ),
       );
 
-      await tester.enterText(find.byType(TextFormField), 'slow@example.com');
-      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.enterText(
+        find.byKey(const Key('email_input')),
+        'slow@example.com',
+      );
+      await tester.tap(find.byKey(const Key('send_otp_button')));
       await tester.pumpAndSettle();
 
       expect(find.text('送信が集中しています。しばらく待ってから再送してください。'), findsOneWidget);
@@ -146,8 +161,11 @@ void main() {
         },
       );
 
-      await tester.enterText(find.byType(TextFormField), 'error@example.com');
-      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.enterText(
+        find.byKey(const Key('email_input')),
+        'error@example.com',
+      );
+      await tester.tap(find.byKey(const Key('send_otp_button')));
       await tester.pumpAndSettle();
 
       expect(
@@ -169,12 +187,17 @@ void main() {
         },
       );
 
-      await tester.enterText(find.byType(TextFormField), 'once@example.com');
-      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.enterText(
+        find.byKey(const Key('email_input')),
+        'once@example.com',
+      );
+      await tester.tap(find.byKey(const Key('send_otp_button')));
       await tester.pump();
 
       expect(callCount, 1);
-      final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      final button = tester.widget<ElevatedButton>(
+        find.byKey(const Key('send_otp_button')),
+      );
       expect(button.onPressed, isNull);
 
       completer.complete(

--- a/test/screens/registration_email_screen_test.dart
+++ b/test/screens/registration_email_screen_test.dart
@@ -1,0 +1,193 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_rpg_app/screens/registration_email_screen.dart';
+import 'package:habit_rpg_app/services/api_service.dart';
+import 'package:habit_rpg_app/services/loading_service.dart';
+import 'package:habit_rpg_app/services/registration_flow_service.dart';
+
+void main() {
+  group('RegistrationEmailScreen', () {
+    late RegistrationFlowService flow;
+    late LoadingService loading;
+    final sentEmails = <String>[];
+
+    Future<void> pumpScreen(
+      WidgetTester tester, {
+      required SendRegistrationOtpRequest sendRegistrationOtp,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RegistrationEmailScreen(
+            sendRegistrationOtpRequest: sendRegistrationOtp,
+            flowService: flow,
+            loadingService: loading,
+          ),
+        ),
+      );
+    }
+
+    setUp(() {
+      flow = RegistrationFlowService();
+      loading = LoadingService();
+      flow.removeAllListeners();
+      flow.reset();
+      loading.clearAll();
+      sentEmails.clear();
+    });
+
+    testWidgets('有効なメール入力で OTP送信処理が呼ばれる', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        sendRegistrationOtp: (email) async {
+          sentEmails.add(email);
+          return const RegistrationApiResult(
+            statusCode: 200,
+            status: RegistrationApiStatus.success,
+            message: 'ok',
+            data: {'retry_after': 60},
+          );
+        },
+      );
+
+      await tester.enterText(
+        find.byType(TextFormField),
+        '  new-user@example.com  ',
+      );
+      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.pumpAndSettle();
+
+      expect(sentEmails, ['new-user@example.com']);
+    });
+
+    testWidgets('成功時に OTP画面へ遷移する', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        sendRegistrationOtp: (email) async => const RegistrationApiResult(
+          statusCode: 200,
+          status: RegistrationApiStatus.success,
+          message: 'ok',
+          data: {'retry_after': 60},
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'next@example.com');
+      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.pumpAndSettle();
+
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+      expect(flow.email, 'next@example.com');
+      expect(flow.resendAvailableAt, isNotNull);
+    });
+
+    testWidgets('409時に既存登録メッセージを表示する', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        sendRegistrationOtp: (_) async => const RegistrationApiResult(
+          statusCode: 409,
+          status: RegistrationApiStatus.conflict,
+          message: 'conflict',
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'dup@example.com');
+      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('このメールアドレスは既に登録済みです。ログイン画面からログインしてください。'),
+        findsOneWidget,
+      );
+      expect(flow.currentStep, RegistrationStep.emailInput);
+    });
+
+    testWidgets('422時に再入力メッセージを表示する', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        sendRegistrationOtp: (_) async => const RegistrationApiResult(
+          statusCode: 422,
+          status: RegistrationApiStatus.unprocessableEntity,
+          message: 'validation',
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'bad@example.com');
+      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('メールアドレスの形式を確認して、もう一度入力してください。'), findsOneWidget);
+      expect(flow.currentStep, RegistrationStep.emailInput);
+    });
+
+    testWidgets('429時に待機メッセージを表示する', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        sendRegistrationOtp: (_) async => const RegistrationApiResult(
+          statusCode: 429,
+          status: RegistrationApiStatus.tooManyRequests,
+          message: 'too many requests',
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'slow@example.com');
+      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('送信が集中しています。しばらく待ってから再送してください。'), findsOneWidget);
+      expect(flow.currentStep, RegistrationStep.emailInput);
+    });
+
+    testWidgets('API例外時にユーザー向けエラーを表示する', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        sendRegistrationOtp: (_) async {
+          throw Exception('network down');
+        },
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'error@example.com');
+      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('ワンタイムパスワードの送信に失敗しました。時間をおいて再度お試しください。'),
+        findsOneWidget,
+      );
+      expect(flow.currentStep, RegistrationStep.emailInput);
+    });
+
+    testWidgets('ローディング中は重複送信を抑止する', (WidgetTester tester) async {
+      final completer = Completer<RegistrationApiResult>();
+      var callCount = 0;
+
+      await pumpScreen(
+        tester,
+        sendRegistrationOtp: (_) {
+          callCount += 1;
+          return completer.future;
+        },
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'once@example.com');
+      await tester.tap(find.text('ワンタイムパスワードを送信'));
+      await tester.pump();
+
+      expect(callCount, 1);
+      final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      expect(button.onPressed, isNull);
+
+      completer.complete(
+        const RegistrationApiResult(
+          statusCode: 200,
+          status: RegistrationApiStatus.success,
+          message: 'ok',
+          data: {'retry_after': 60},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **テスト**
  * メール登録フローの包括的なウィジェットテストを追加。成功／失敗ケース、各種HTTPエラー、バリデーション、ローディング挙動、重複送信抑制を検証

* **改善**
  * 登録時のエラー表示と遷移制御を強化：入力検証、失敗時のユーザ向けメッセージ、成功時のOTP検証画面への確実な遷移を改善
<!-- end of auto-generated comment: release notes by coderabbit.ai -->