### PR TITLE
Test/84 registration opt

### DIFF
--- a/lib/screens/registration_otp_screen.dart
+++ b/lib/screens/registration_otp_screen.dart
@@ -38,8 +38,8 @@ class _RegistrationOtpScreenState extends State<RegistrationOtpScreen> {
   final _formKey = GlobalKey<FormState>();
   final _otpController = TextEditingController();
   final _apiService = ApiService();
-  late final LoadingService _loadingService;
-  late final RegistrationFlowService _flow;
+  late LoadingService _loadingService;
+  late RegistrationFlowService _flow;
 
   static const String _loadingOperation = 'registration_otp_step';
   static const Duration _defaultResendCooldown = Duration(seconds: 60);
@@ -57,6 +57,17 @@ class _RegistrationOtpScreenState extends State<RegistrationOtpScreen> {
         setState(() {});
       }
     });
+  }
+
+  @override
+  void didUpdateWidget(covariant RegistrationOtpScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.loadingService != widget.loadingService) {
+      _loadingService = widget.loadingService ?? LoadingService();
+    }
+    if (oldWidget.flowService != widget.flowService) {
+      _flow = widget.flowService ?? RegistrationFlowService();
+    }
   }
 
   @override

--- a/lib/screens/registration_otp_screen.dart
+++ b/lib/screens/registration_otp_screen.dart
@@ -8,8 +8,27 @@ import '../services/registration_flow_service.dart';
 import '../utils/registration_response_parsing.dart';
 import '../widgets/loading_widget.dart';
 
+typedef VerifyRegistrationOtpRequest =
+    Future<RegistrationApiResult> Function({
+      required String email,
+      required String otp,
+    });
+typedef SendRegistrationOtpRequest =
+    Future<RegistrationApiResult> Function(String email);
+
 class RegistrationOtpScreen extends StatefulWidget {
-  const RegistrationOtpScreen({super.key});
+  final VerifyRegistrationOtpRequest? verifyRegistrationOtpRequest;
+  final SendRegistrationOtpRequest? sendRegistrationOtpRequest;
+  final RegistrationFlowService? flowService;
+  final LoadingService? loadingService;
+
+  const RegistrationOtpScreen({
+    super.key,
+    this.verifyRegistrationOtpRequest,
+    this.sendRegistrationOtpRequest,
+    this.flowService,
+    this.loadingService,
+  });
 
   @override
   State<RegistrationOtpScreen> createState() => _RegistrationOtpScreenState();
@@ -19,8 +38,8 @@ class _RegistrationOtpScreenState extends State<RegistrationOtpScreen> {
   final _formKey = GlobalKey<FormState>();
   final _otpController = TextEditingController();
   final _apiService = ApiService();
-  final _loadingService = LoadingService();
-  final _flow = RegistrationFlowService();
+  late final LoadingService _loadingService;
+  late final RegistrationFlowService _flow;
 
   static const String _loadingOperation = 'registration_otp_step';
   static const Duration _defaultResendCooldown = Duration(seconds: 60);
@@ -31,6 +50,8 @@ class _RegistrationOtpScreenState extends State<RegistrationOtpScreen> {
   @override
   void initState() {
     super.initState();
+    _loadingService = widget.loadingService ?? LoadingService();
+    _flow = widget.flowService ?? RegistrationFlowService();
     _tickTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (mounted) {
         setState(() {});
@@ -64,7 +85,10 @@ class _RegistrationOtpScreenState extends State<RegistrationOtpScreen> {
     _loadingService.setLoading(_loadingOperation, true);
 
     try {
-      final result = await _apiService.verifyRegistrationOtp(
+      final verifyRegistrationOtp =
+          widget.verifyRegistrationOtpRequest ??
+          _apiService.verifyRegistrationOtp;
+      final result = await verifyRegistrationOtp(
         email: _flow.email,
         otp: _otpController.text.trim(),
       );
@@ -110,7 +134,9 @@ class _RegistrationOtpScreenState extends State<RegistrationOtpScreen> {
     _loadingService.setLoading(_loadingOperation, true);
 
     try {
-      final result = await _apiService.sendRegistrationOtp(_flow.email);
+      final sendRegistrationOtp =
+          widget.sendRegistrationOtpRequest ?? _apiService.sendRegistrationOtp;
+      final result = await sendRegistrationOtp(_flow.email);
 
       if (!mounted) {
         return;
@@ -160,6 +186,7 @@ class _RegistrationOtpScreenState extends State<RegistrationOtpScreen> {
           title: const Text('ワンタイムパスワード入力'),
           backgroundColor: Theme.of(context).colorScheme.inversePrimary,
           leading: IconButton(
+            key: const Key('otp_back_button'),
             icon: const Icon(Icons.arrow_back),
             onPressed: _anyLoading ? null : () => _flow.goBack(),
           ),
@@ -177,6 +204,7 @@ class _RegistrationOtpScreenState extends State<RegistrationOtpScreen> {
                 ),
                 const SizedBox(height: 24),
                 TextFormField(
+                  key: const Key('otp_input'),
                   controller: _otpController,
                   keyboardType: TextInputType.number,
                   maxLength: 6,
@@ -215,6 +243,7 @@ class _RegistrationOtpScreenState extends State<RegistrationOtpScreen> {
                 ],
                 const SizedBox(height: 16),
                 TextButton(
+                  key: const Key('otp_resend_button'),
                   onPressed: (!_anyLoading && canResend) ? _resend : null,
                   child: const Text('コードを再送する'),
                 ),
@@ -222,6 +251,7 @@ class _RegistrationOtpScreenState extends State<RegistrationOtpScreen> {
                 SizedBox(
                   height: 50,
                   child: ElevatedButton(
+                    key: const Key('otp_verify_button'),
                     onPressed: _anyLoading ? null : _verify,
                     child: Text(
                       _loadingService.isLoading(_loadingOperation)

--- a/test/screens/registration_otp_screen_test.dart
+++ b/test/screens/registration_otp_screen_test.dart
@@ -1,0 +1,265 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_rpg_app/screens/registration_otp_screen.dart';
+import 'package:habit_rpg_app/services/api_service.dart';
+import 'package:habit_rpg_app/services/loading_service.dart';
+import 'package:habit_rpg_app/services/registration_flow_service.dart';
+
+void main() {
+  group('RegistrationOtpScreen', () {
+    late RegistrationFlowService flow;
+    late LoadingService loading;
+
+    Future<void> pumpScreen(
+      WidgetTester tester, {
+      VerifyRegistrationOtpRequest? verifyRegistrationOtp,
+      SendRegistrationOtpRequest? sendRegistrationOtp,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RegistrationOtpScreen(
+            verifyRegistrationOtpRequest:
+                verifyRegistrationOtp ??
+                ({required String email, required String otp}) async =>
+                    const RegistrationApiResult(
+                      statusCode: 200,
+                      status: RegistrationApiStatus.success,
+                      message: 'ok',
+                      data: {'registration_token': 'token-default'},
+                    ),
+            sendRegistrationOtpRequest:
+                sendRegistrationOtp ??
+                (_) async => const RegistrationApiResult(
+                  statusCode: 200,
+                  status: RegistrationApiStatus.success,
+                  message: 'ok',
+                  data: {'retry_after': 60},
+                ),
+            flowService: flow,
+            loadingService: loading,
+          ),
+        ),
+      );
+    }
+
+    setUp(() {
+      flow = RegistrationFlowService();
+      loading = LoadingService();
+      flow.removeAllListeners();
+      flow.reset();
+      loading.clearAll();
+      flow.moveToOtpVerification(
+        email: 'new-user@example.com',
+        resendAvailableAt: DateTime.now().subtract(const Duration(seconds: 1)),
+      );
+    });
+
+    testWidgets('正しいOTPで registration_token を受け取り passwordSetup に遷移する', (
+      WidgetTester tester,
+    ) async {
+      String? requestedEmail;
+      String? requestedOtp;
+
+      await pumpScreen(
+        tester,
+        verifyRegistrationOtp:
+            ({required String email, required String otp}) async {
+              requestedEmail = email;
+              requestedOtp = otp;
+              return const RegistrationApiResult(
+                statusCode: 200,
+                status: RegistrationApiStatus.success,
+                message: 'ok',
+                data: {'registration_token': 'token-123'},
+              );
+            },
+      );
+
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+      await tester.enterText(find.byKey(const Key('otp_input')), '123456');
+      await tester.tap(find.byKey(const Key('otp_verify_button')));
+      await tester.pumpAndSettle();
+
+      expect(requestedEmail, 'new-user@example.com');
+      expect(requestedOtp, '123456');
+      expect(flow.currentStep, RegistrationStep.passwordSetup);
+      expect(flow.registrationToken, 'token-123');
+    });
+
+    testWidgets('再送成功時にクールダウン情報が反映される', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        sendRegistrationOtp: (_) async => const RegistrationApiResult(
+          statusCode: 200,
+          status: RegistrationApiStatus.success,
+          message: 'ok',
+          data: {'retry_after': 120},
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('otp_resend_button')));
+      await tester.pumpAndSettle();
+
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+      expect(flow.canResendOtp(), isFalse);
+      expect(flow.resendRemaining().inSeconds, greaterThanOrEqualTo(110));
+      expect(find.textContaining('再送まであと'), findsOneWidget);
+    });
+
+    testWidgets('誤OTP(422)時にメッセージを表示して状態維持する', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        verifyRegistrationOtp:
+            ({required String email, required String otp}) async =>
+                const RegistrationApiResult(
+                  statusCode: 422,
+                  status: RegistrationApiStatus.unprocessableEntity,
+                  message: 'validation',
+                ),
+      );
+
+      await tester.enterText(find.byKey(const Key('otp_input')), '123456');
+      await tester.tap(find.byKey(const Key('otp_verify_button')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('コードが正しくないか有効期限切れです。再入力するか、コードを再送してください。'),
+        findsOneWidget,
+      );
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+    });
+
+    testWidgets('試行超過(429)時にメッセージを表示して状態維持する', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        verifyRegistrationOtp:
+            ({required String email, required String otp}) async =>
+                const RegistrationApiResult(
+                  statusCode: 429,
+                  status: RegistrationApiStatus.tooManyRequests,
+                  message: 'too many requests',
+                ),
+      );
+
+      await tester.enterText(find.byKey(const Key('otp_input')), '123456');
+      await tester.tap(find.byKey(const Key('otp_verify_button')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('試行回数の上限に達しました。しばらく待ってからコードを再送してください。'), findsOneWidget);
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+    });
+
+    testWidgets('OTP検証API例外時にユーザー向けエラーを表示する', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        verifyRegistrationOtp:
+            ({required String email, required String otp}) async {
+              throw Exception('network down');
+            },
+      );
+
+      await tester.enterText(find.byKey(const Key('otp_input')), '123456');
+      await tester.tap(find.byKey(const Key('otp_verify_button')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('ワンタイムパスワードの検証に失敗しました。時間をおいて再度お試しください。'),
+        findsOneWidget,
+      );
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+    });
+
+    testWidgets('再送失敗(429)時にメッセージを表示して状態維持する', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        sendRegistrationOtp: (_) async => const RegistrationApiResult(
+          statusCode: 429,
+          status: RegistrationApiStatus.tooManyRequests,
+          message: 'too many requests',
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('otp_resend_button')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('送信が集中しています。しばらく待ってから再送してください。'), findsOneWidget);
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+    });
+
+    testWidgets('再送API例外時にユーザー向けエラーを表示する', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        sendRegistrationOtp: (_) async {
+          throw Exception('network down');
+        },
+      );
+
+      await tester.tap(find.byKey(const Key('otp_resend_button')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('ワンタイムパスワードの再送に失敗しました。時間をおいて再度お試しください。'),
+        findsOneWidget,
+      );
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+    });
+
+    testWidgets('ローディング中は戻る/重複操作が抑止される', (WidgetTester tester) async {
+      final completer = Completer<RegistrationApiResult>();
+      var verifyCallCount = 0;
+      var resendCallCount = 0;
+
+      await pumpScreen(
+        tester,
+        verifyRegistrationOtp: ({required String email, required String otp}) {
+          verifyCallCount += 1;
+          return completer.future;
+        },
+        sendRegistrationOtp: (_) async {
+          resendCallCount += 1;
+          return const RegistrationApiResult(
+            statusCode: 200,
+            status: RegistrationApiStatus.success,
+            message: 'ok',
+            data: {'retry_after': 60},
+          );
+        },
+      );
+
+      await tester.enterText(find.byKey(const Key('otp_input')), '123456');
+      await tester.tap(find.byKey(const Key('otp_verify_button')));
+      await tester.pump();
+
+      expect(verifyCallCount, 1);
+      expect(resendCallCount, 0);
+
+      final verifyButton = tester.widget<ElevatedButton>(
+        find.byKey(const Key('otp_verify_button')),
+      );
+      final resendButton = tester.widget<TextButton>(
+        find.byKey(const Key('otp_resend_button')),
+      );
+      final backButton = tester.widget<IconButton>(
+        find.byKey(const Key('otp_back_button')),
+      );
+      expect(verifyButton.onPressed, isNull);
+      expect(resendButton.onPressed, isNull);
+      expect(backButton.onPressed, isNull);
+
+      completer.complete(
+        const RegistrationApiResult(
+          statusCode: 200,
+          status: RegistrationApiStatus.success,
+          message: 'ok',
+          data: {'registration_token': 'token-after-loading'},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(flow.currentStep, RegistrationStep.passwordSetup);
+      expect(flow.registrationToken, 'token-after-loading');
+    });
+  });
+}

--- a/test/screens/registration_otp_screen_test.dart
+++ b/test/screens/registration_otp_screen_test.dart
@@ -99,12 +99,13 @@ void main() {
         ),
       );
 
+      expect(flow.canResendOtp(), isTrue);
       await tester.tap(find.byKey(const Key('otp_resend_button')));
       await tester.pumpAndSettle();
 
       expect(flow.currentStep, RegistrationStep.otpVerification);
       expect(flow.canResendOtp(), isFalse);
-      expect(flow.resendRemaining().inSeconds, greaterThanOrEqualTo(110));
+      expect(flow.resendRemaining().inSeconds, inInclusiveRange(100, 120));
       expect(find.textContaining('再送まであと'), findsOneWidget);
     });
 

--- a/test/screens/registration_otp_screen_test.dart
+++ b/test/screens/registration_otp_screen_test.dart
@@ -88,6 +88,40 @@ void main() {
       expect(flow.registrationToken, 'token-123');
     });
 
+    testWidgets('成功レスポンスでも registration_token 欠落時は遷移しない', (
+      WidgetTester tester,
+    ) async {
+      String? requestedEmail;
+      String? requestedOtp;
+
+      await pumpScreen(
+        tester,
+        verifyRegistrationOtp:
+            ({required String email, required String otp}) async {
+              requestedEmail = email;
+              requestedOtp = otp;
+              return const RegistrationApiResult(
+                statusCode: 200,
+                status: RegistrationApiStatus.success,
+                message: 'ok',
+                data: {},
+              );
+            },
+      );
+
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+      expect(flow.registrationToken, isNull);
+      await tester.enterText(find.byKey(const Key('otp_input')), '123456');
+      await tester.tap(find.byKey(const Key('otp_verify_button')));
+      await tester.pumpAndSettle();
+
+      expect(requestedEmail, 'new-user@example.com');
+      expect(requestedOtp, '123456');
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+      expect(flow.registrationToken, isNull);
+      expect(find.text('登録トークンを取得できませんでした。最初からやり直してください。'), findsOneWidget);
+    });
+
     testWidgets('再送成功時にクールダウン情報が反映される', (WidgetTester tester) async {
       await pumpScreen(
         tester,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * OTP送信・検証フローでの再送クールダウン表示と無効化、検証後の次画面への遷移（登録トークン保存）を強化しました。
  * 検証・再送中は操作を抑制して多重実行を防止します。

* **テスト**
  * OTP認証画面の包括的なウィジェットテストを追加し、成功／失敗／レート制限／例外時の表示と遷移を検証しました。

* **リファクタリング**
  * 画面の公開APIを拡張し、リクエスト処理や初期化の差し替えが可能になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->