### PR TITLE
Test/85 registration flow page

### DIFF
--- a/lib/screens/registration_flow_page.dart
+++ b/lib/screens/registration_flow_page.dart
@@ -45,6 +45,19 @@ class _RegistrationFlowPageState extends State<RegistrationFlowPage> {
   }
 
   @override
+  void didUpdateWidget(covariant RegistrationFlowPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    assert(
+      identical(oldWidget.flowService, widget.flowService),
+      'RegistrationFlowPage does not support swapping flowService after mount.',
+    );
+    assert(
+      identical(oldWidget.loadingService, widget.loadingService),
+      'RegistrationFlowPage does not support swapping loadingService after mount.',
+    );
+  }
+
+  @override
   void dispose() {
     widget.onFlowDispose?.call(_flow);
     if (_ownsFlowService) {

--- a/lib/screens/registration_flow_page.dart
+++ b/lib/screens/registration_flow_page.dart
@@ -26,12 +26,19 @@ class RegistrationFlowPage extends StatefulWidget {
 class _RegistrationFlowPageState extends State<RegistrationFlowPage> {
   late final RegistrationFlowService _flow;
   late final LoadingService _loadingService;
+  late final bool _ownsFlowService;
+  late final bool _ownsLoadingService;
+
+  bool get _isSharedLoadingService =>
+      identical(_loadingService, LoadingService());
 
   bool get _isLoading => _loadingService.isAnyLoading;
 
   @override
   void initState() {
     super.initState();
+    _ownsFlowService = widget.flowService == null;
+    _ownsLoadingService = widget.loadingService == null;
     _flow = widget.flowService ?? RegistrationFlowService();
     _loadingService = widget.loadingService ?? LoadingService();
     _flow.reset();
@@ -39,8 +46,14 @@ class _RegistrationFlowPageState extends State<RegistrationFlowPage> {
 
   @override
   void dispose() {
-    _flow.dispose();
     widget.onFlowDispose?.call(_flow);
+    if (_ownsFlowService) {
+      _flow.dispose();
+    }
+    // LoadingService は singleton のため、共有インスタンスは破棄しない。
+    if (_ownsLoadingService && !_isSharedLoadingService) {
+      _loadingService.dispose();
+    }
     super.dispose();
   }
 

--- a/lib/screens/registration_flow_page.dart
+++ b/lib/screens/registration_flow_page.dart
@@ -8,27 +8,39 @@ import 'registration_password_setup_screen.dart';
 
 /// 会員登録（メール・OTP・パスワード）のステップ切り替え。
 class RegistrationFlowPage extends StatefulWidget {
-  const RegistrationFlowPage({super.key});
+  final RegistrationFlowService? flowService;
+  final LoadingService? loadingService;
+  final void Function(RegistrationFlowService flowService)? onFlowDispose;
+
+  const RegistrationFlowPage({
+    super.key,
+    this.flowService,
+    this.loadingService,
+    this.onFlowDispose,
+  });
 
   @override
   State<RegistrationFlowPage> createState() => _RegistrationFlowPageState();
 }
 
 class _RegistrationFlowPageState extends State<RegistrationFlowPage> {
-  final RegistrationFlowService _flow = RegistrationFlowService();
-  final LoadingService _loadingService = LoadingService();
+  late final RegistrationFlowService _flow;
+  late final LoadingService _loadingService;
 
   bool get _isLoading => _loadingService.isAnyLoading;
 
   @override
   void initState() {
     super.initState();
+    _flow = widget.flowService ?? RegistrationFlowService();
+    _loadingService = widget.loadingService ?? LoadingService();
     _flow.reset();
   }
 
   @override
   void dispose() {
     _flow.dispose();
+    widget.onFlowDispose?.call(_flow);
     super.dispose();
   }
 

--- a/test/screens/registration_flow_page_test.dart
+++ b/test/screens/registration_flow_page_test.dart
@@ -135,5 +135,39 @@ void main() {
 
       expect(disposed, isTrue);
     });
+
+    testWidgets('DIなしでも開閉時に例外なく動作する', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const RegistrationFlowPage(),
+                      ),
+                    );
+                  },
+                  child: const Text('open-default-flow'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open-default-flow'));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('reg_email')), findsOneWidget);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('open-default-flow'), findsOneWidget);
+      expect(find.byKey(const ValueKey('reg_email')), findsNothing);
+    });
   });
 }

--- a/test/screens/registration_flow_page_test.dart
+++ b/test/screens/registration_flow_page_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_rpg_app/screens/registration_flow_page.dart';
+import 'package:habit_rpg_app/services/loading_service.dart';
+import 'package:habit_rpg_app/services/registration_flow_service.dart';
+
+void main() {
+  group('RegistrationFlowPage', () {
+    late RegistrationFlowService flow;
+    late LoadingService loading;
+
+    Future<void> pumpHostApp(
+      WidgetTester tester, {
+      void Function(RegistrationFlowService flowService)? onFlowDispose,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => RegistrationFlowPage(
+                          flowService: flow,
+                          loadingService: loading,
+                          onFlowDispose: onFlowDispose,
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('open-flow'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open-flow'));
+      await tester.pumpAndSettle();
+    }
+
+    setUp(() {
+      flow = RegistrationFlowService();
+      loading = LoadingService();
+      flow.removeAllListeners();
+      flow.reset();
+      loading.clearAll();
+    });
+
+    testWidgets('ステップごとに正しい画面が表示される', (WidgetTester tester) async {
+      await pumpHostApp(tester);
+
+      expect(find.byKey(const ValueKey('reg_email')), findsOneWidget);
+
+      flow.moveToOtpVerification(
+        email: 'new-user@example.com',
+        resendAvailableAt: DateTime.now(),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('reg_otp')), findsOneWidget);
+
+      flow.moveToPasswordSetup(registrationToken: 'token-123');
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('reg_password')), findsOneWidget);
+
+      flow.completeRegistration();
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('reg_done')), findsOneWidget);
+    });
+
+    testWidgets('戻れるステップでは1段戻る', (WidgetTester tester) async {
+      await pumpHostApp(tester);
+
+      flow.moveToOtpVerification(
+        email: 'new-user@example.com',
+        resendAvailableAt: DateTime.now(),
+      );
+      flow.moveToPasswordSetup(registrationToken: 'token-123');
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('reg_password')), findsOneWidget);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+      expect(find.byKey(const ValueKey('reg_otp')), findsOneWidget);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+      expect(flow.currentStep, RegistrationStep.emailInput);
+      expect(find.byKey(const ValueKey('reg_email')), findsOneWidget);
+    });
+
+    testWidgets('先頭ステップではページを閉じる', (WidgetTester tester) async {
+      await pumpHostApp(tester);
+      expect(find.byKey(const ValueKey('reg_email')), findsOneWidget);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(find.text('open-flow'), findsOneWidget);
+      expect(find.byKey(const ValueKey('reg_email')), findsNothing);
+    });
+
+    testWidgets('ローディング中は戻る操作を無効化する', (WidgetTester tester) async {
+      await pumpHostApp(tester);
+      expect(find.byKey(const ValueKey('reg_email')), findsOneWidget);
+
+      loading.setLoading('registration_send_otp', true);
+      await tester.pump();
+
+      await tester.binding.handlePopRoute();
+      await tester.pump();
+
+      expect(find.byKey(const ValueKey('reg_email')), findsOneWidget);
+      expect(find.text('open-flow'), findsNothing);
+      expect(flow.currentStep, RegistrationStep.emailInput);
+    });
+
+    testWidgets('dispose時にFlowServiceのdispose経路が呼ばれる', (
+      WidgetTester tester,
+    ) async {
+      var disposed = false;
+      await pumpHostApp(
+        tester,
+        onFlowDispose: (_) {
+          disposed = true;
+        },
+      );
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(disposed, isTrue);
+    });
+  });
+}

--- a/test/screens/registration_flow_page_test.dart
+++ b/test/screens/registration_flow_page_test.dart
@@ -104,7 +104,7 @@ void main() {
       expect(find.byKey(const ValueKey('reg_email')), findsNothing);
     });
 
-    testWidgets('ローディング中は戻る操作を無効化する', (WidgetTester tester) async {
+    testWidgets('ローディング中は先頭ステップで戻る操作を無効化する', (WidgetTester tester) async {
       await pumpHostApp(tester);
       expect(find.byKey(const ValueKey('reg_email')), findsOneWidget);
 
@@ -119,7 +119,29 @@ void main() {
       expect(flow.currentStep, RegistrationStep.emailInput);
     });
 
-    testWidgets('dispose時にFlowServiceのdispose経路が呼ばれる', (
+    testWidgets('ローディング中は戻れるステップでも戻らない', (WidgetTester tester) async {
+      await pumpHostApp(tester);
+
+      flow.moveToOtpVerification(
+        email: 'new-user@example.com',
+        resendAvailableAt: DateTime.now(),
+      );
+      await tester.pumpAndSettle();
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+      expect(find.byKey(const ValueKey('reg_otp')), findsOneWidget);
+
+      loading.setLoading('registration_send_otp', true);
+      await tester.pump();
+
+      await tester.binding.handlePopRoute();
+      await tester.pump();
+
+      expect(flow.currentStep, RegistrationStep.otpVerification);
+      expect(find.byKey(const ValueKey('reg_otp')), findsOneWidget);
+      expect(find.text('open-flow'), findsNothing);
+    });
+
+    testWidgets('dispose時にonFlowDisposeコールバックが呼ばれる', (
       WidgetTester tester,
     ) async {
       var disposed = false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 登録フロー画面が外部提供のサービスインスタンスを受け取れるようになりました（任意）。
* **改善**
  * サービスの所有権に基づく破棄制御を導入し、共有インスタンスの誤破棄を防止。
  * フロー破棄時に呼ばれるコールバックを追加。
  * ローディング中は戻る操作を無視して誤操作を防止。
* **テスト**
  * 登録フローのウィジェットテストを追加（各ステップ・戻る挙動・破棄動作・既定利用を検証）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->