### PR TITLE
Test/86 regstration api status

### DIFF
--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -142,9 +142,14 @@ class ApiService {
   final http.Client _httpClient;
   final AuthService _authService;
   final bool _ownsHttpClient;
+  bool get _isSingletonInstance => identical(this, _instance);
 
-  /// Injected [http.Client] instances are managed by the caller and are not closed here.
+  /// 注入された [http.Client] は呼び出し元で管理し、このサービスでは close しません
   void dispose() {
+    if (_isSingletonInstance) {
+      // singleton はアプリ全体で共有されるため、外部から dispose しない
+      return;
+    }
     if (_ownsHttpClient) {
       _httpClient.close();
     }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -122,11 +122,22 @@ class RegistrationApiResult {
 
 class ApiService {
   static final ApiService _instance = ApiService._internal();
-  factory ApiService() => _instance;
-  ApiService._internal();
+  factory ApiService({http.Client? httpClient, AuthService? authService}) {
+    if (httpClient != null || authService != null) {
+      return ApiService._internal(
+        httpClient: httpClient,
+        authService: authService,
+      );
+    }
+    return _instance;
+  }
+  ApiService._internal({http.Client? httpClient, AuthService? authService})
+    : _httpClient = httpClient ?? http.Client(),
+      _authService = authService ?? AuthService();
 
   final String _baseUrl = EnvironmentConfig.baseUrl;
-  final AuthService _authService = AuthService();
+  final http.Client _httpClient;
+  final AuthService _authService;
 
   // ヘッダーの設定（認証トークンを自動付与）
   Future<Map<String, String>> get _headers async {
@@ -149,7 +160,7 @@ class ApiService {
     try {
       final normalizedEmail = email.trim();
       final headers = await _headers;
-      final response = await http.post(
+      final response = await _httpClient.post(
         Uri.parse('$_baseUrl/api/auth/login'),
         headers: headers,
         body: jsonEncode({'email': normalizedEmail, 'password': password}),
@@ -255,7 +266,10 @@ class ApiService {
   Future<void> logout() async {
     try {
       final headers = await _headers;
-      await http.post(Uri.parse('$_baseUrl/api/auth/logout'), headers: headers);
+      await _httpClient.post(
+        Uri.parse('$_baseUrl/api/auth/logout'),
+        headers: headers,
+      );
     } catch (e) {
       // エラーが発生してもローカルのトークンは削除する
       // ignore: avoid_print
@@ -270,7 +284,7 @@ class ApiService {
   Future<List<Task>> getTasks() async {
     try {
       final headers = await _headers;
-      final response = await http.get(
+      final response = await _httpClient.get(
         Uri.parse('$_baseUrl/api/tasks'),
         headers: headers,
       );
@@ -337,7 +351,7 @@ class ApiService {
     try {
       final headers = await _headers;
 
-      final response = await http.post(
+      final response = await _httpClient.post(
         Uri.parse('$_baseUrl/api/tasks'),
         headers: headers,
         body: jsonEncode({
@@ -400,7 +414,7 @@ class ApiService {
     try {
       final headers = await _headers;
 
-      final response = await http.put(
+      final response = await _httpClient.put(
         Uri.parse('$_baseUrl/api/tasks/$uuid'),
         headers: headers,
         body: jsonEncode({
@@ -469,7 +483,7 @@ class ApiService {
   Future<void> deleteTask(String uuid) async {
     try {
       final headers = await _headers;
-      final response = await http.delete(
+      final response = await _httpClient.delete(
         Uri.parse('$_baseUrl/api/tasks/$uuid'),
         headers: headers,
       );
@@ -508,7 +522,7 @@ class ApiService {
   }) async {
     try {
       final headers = await _headers;
-      final response = await http.patch(
+      final response = await _httpClient.patch(
         Uri.parse('$_baseUrl/api/tasks/$uuid/complete'),
         headers: headers,
         body: jsonEncode({'is_completed': isCompleted}),
@@ -554,7 +568,7 @@ class ApiService {
   Future<User> getUser() async {
     try {
       final headers = await _headers;
-      final response = await http.get(
+      final response = await _httpClient.get(
         Uri.parse('$_baseUrl/api/user'),
         headers: headers,
       );
@@ -603,7 +617,7 @@ class ApiService {
       if (isDarkMode != null) body['is_dark_mode'] = isDarkMode;
       if (is24HourFormat != null) body['is_24_hour_format'] = is24HourFormat;
 
-      final response = await http.put(
+      final response = await _httpClient.put(
         Uri.parse('$_baseUrl/api/user'),
         headers: headers,
         body: jsonEncode(body),
@@ -639,7 +653,7 @@ class ApiService {
   Future<void> deleteAccount() async {
     try {
       final headers = await _headers;
-      final response = await http.delete(
+      final response = await _httpClient.delete(
         Uri.parse('$_baseUrl/api/user'),
         headers: headers,
       );
@@ -670,7 +684,7 @@ class ApiService {
   Future<List<TaskSuggestion>> getTaskSuggestions() async {
     try {
       final headers = await _headers;
-      final response = await http.get(
+      final response = await _httpClient.get(
         Uri.parse('$_baseUrl/api/task-suggestions'),
         headers: headers,
       );
@@ -734,7 +748,7 @@ class ApiService {
   Future<void> deleteTaskSuggestion(String uuid) async {
     try {
       final headers = await _headers;
-      final response = await http.delete(
+      final response = await _httpClient.delete(
         Uri.parse('$_baseUrl/api/task-suggestions/$uuid'),
         headers: headers,
       );
@@ -781,7 +795,7 @@ class ApiService {
 
     try {
       final headers = await _headers;
-      final response = await http
+      final response = await _httpClient
           .post(
             Uri.parse('$_baseUrl$endpoint'),
             headers: headers,

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -121,6 +121,8 @@ class RegistrationApiResult {
 }
 
 class ApiService {
+  static final RegExp _emailPattern = RegExp(r'^[^\s@]+@[^\s@]+\.[^\s@]+$');
+
   static final ApiService _instance = ApiService._internal();
   factory ApiService({http.Client? httpClient, AuthService? authService}) {
     if (httpClient != null || authService != null) {
@@ -133,11 +135,20 @@ class ApiService {
   }
   ApiService._internal({http.Client? httpClient, AuthService? authService})
     : _httpClient = httpClient ?? http.Client(),
-      _authService = authService ?? AuthService();
+      _authService = authService ?? AuthService(),
+      _ownsHttpClient = httpClient == null;
 
   final String _baseUrl = EnvironmentConfig.baseUrl;
   final http.Client _httpClient;
   final AuthService _authService;
+  final bool _ownsHttpClient;
+
+  /// Injected [http.Client] instances are managed by the caller and are not closed here.
+  void dispose() {
+    if (_ownsHttpClient) {
+      _httpClient.close();
+    }
+  }
 
   // ヘッダーの設定（認証トークンを自動付与）
   Future<Map<String, String>> get _headers async {
@@ -218,6 +229,10 @@ class ApiService {
   // 会員登録OTP送信API
   Future<RegistrationApiResult> sendRegistrationOtp(String email) async {
     final normalizedEmail = email.trim();
+    final validationResult = _validateRegistrationEmail(normalizedEmail);
+    if (validationResult != null) {
+      return validationResult;
+    }
     return _postRegistrationApi(
       endpoint: '/api/auth/register/otp/send',
       body: {'email': normalizedEmail},
@@ -884,6 +899,32 @@ class ApiService {
     if (errors is Map) {
       return errors.map((key, value) => MapEntry(key.toString(), value));
     }
+    return null;
+  }
+
+  RegistrationApiResult? _validateRegistrationEmail(String email) {
+    if (email.isEmpty) {
+      return const RegistrationApiResult(
+        statusCode: 422,
+        status: RegistrationApiStatus.unprocessableEntity,
+        message: 'メールアドレスを入力してください。',
+        errors: {
+          'email': ['メールアドレスを入力してください。'],
+        },
+      );
+    }
+
+    if (email.length > 254 || !_emailPattern.hasMatch(email)) {
+      return const RegistrationApiResult(
+        statusCode: 422,
+        status: RegistrationApiStatus.unprocessableEntity,
+        message: 'メールアドレスの形式が正しくありません。',
+        errors: {
+          'email': ['メールアドレスの形式が正しくありません。'],
+        },
+      );
+    }
+
     return null;
   }
 }

--- a/test/services/api_service_test.dart
+++ b/test/services/api_service_test.dart
@@ -120,7 +120,12 @@ void main() {
       Future<http.Response> Function(http.Request request) handler,
     ) {
       final mockClient = MockClient(handler);
-      return ApiService(httpClient: mockClient, authService: authService);
+      final service = ApiService(
+        httpClient: mockClient,
+        authService: authService,
+      );
+      addTearDown(service.dispose);
+      return service;
     }
 
     test('sendRegistrationOtp: 主要HTTPステータスを正規化できる', () async {
@@ -192,6 +197,33 @@ void main() {
       final longEmail = '${List.filled(1001, 'a').join()}@example.com';
 
       final result = await service.sendRegistrationOtp(longEmail);
+      expect(result.statusCode, 422);
+      expect(result.status, RegistrationApiStatus.unprocessableEntity);
+      expect(result.isValidationError, isTrue);
+    });
+
+    test('sendRegistrationOtp: 254文字メールは送信できる', () async {
+      var httpCalled = false;
+      final service = buildService((request) async {
+        httpCalled = true;
+        expect(request.url.path, '/api/auth/register/otp/send');
+        return http.Response(jsonEncode({'message': 'ok'}), 200);
+      });
+      final email254 = '${List.filled(242, 'a').join()}@example.com';
+
+      final result = await service.sendRegistrationOtp(email254);
+      expect(result.statusCode, 200);
+      expect(result.status, RegistrationApiStatus.success);
+      expect(httpCalled, isTrue);
+    });
+
+    test('sendRegistrationOtp: 255文字メールはHTTPリクエストせず422を返す', () async {
+      final service = buildService((_) async {
+        fail('HTTP request should not be made for 255-char email');
+      });
+      final email255 = '${List.filled(243, 'a').join()}@example.com';
+
+      final result = await service.sendRegistrationOtp(email255);
       expect(result.statusCode, 422);
       expect(result.status, RegistrationApiStatus.unprocessableEntity);
       expect(result.isValidationError, isTrue);

--- a/test/services/api_service_test.dart
+++ b/test/services/api_service_test.dart
@@ -1,4 +1,8 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:habit_rpg_app/services/api_service.dart';
 import 'package:habit_rpg_app/services/auth_service.dart';
@@ -97,6 +101,155 @@ void main() {
       expect(conflictResult.isConflict, true);
       expect(tooManyRequestsResult.isTooManyRequests, true);
       expect(tooManyRequestsResult.isValidationError, false);
+    });
+  });
+
+  group('ApiService registration mapping', () {
+    late AuthService authService;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      authService = AuthService();
+    });
+
+    tearDown(() async {
+      await authService.logout();
+    });
+
+    ApiService buildService(
+      Future<http.Response> Function(http.Request request) handler,
+    ) {
+      final mockClient = MockClient(handler);
+      return ApiService(httpClient: mockClient, authService: authService);
+    }
+
+    test('sendRegistrationOtp: 主要HTTPステータスを正規化できる', () async {
+      final cases = <int, RegistrationApiStatus>{
+        200: RegistrationApiStatus.success,
+        409: RegistrationApiStatus.conflict,
+        422: RegistrationApiStatus.unprocessableEntity,
+        429: RegistrationApiStatus.tooManyRequests,
+        500: RegistrationApiStatus.unknownError,
+      };
+
+      for (final entry in cases.entries) {
+        final service = buildService((request) async {
+          expect(request.url.path, '/api/auth/register/otp/send');
+          final decoded = jsonDecode(request.body) as Map<String, dynamic>;
+          expect(decoded['email'], 'new-user@example.com');
+          return http.Response(
+            jsonEncode({'message': 'status-${entry.key}'}),
+            entry.key,
+          );
+        });
+
+        final result = await service.sendRegistrationOtp(
+          '  new-user@example.com  ',
+        );
+        expect(result.statusCode, entry.key);
+        expect(result.status, entry.value);
+        expect(result.message, 'status-${entry.key}');
+      }
+    });
+
+    test('sendRegistrationOtp: ネットワーク例外は networkError にマッピングされる', () async {
+      final service = buildService((_) async {
+        throw Exception('network down');
+      });
+
+      final result = await service.sendRegistrationOtp('user@example.com');
+      expect(result.statusCode, 0);
+      expect(result.status, RegistrationApiStatus.networkError);
+      expect(result.message, 'ワンタイムパスワードの送信に失敗しました。');
+    });
+
+    test('verifyRegistrationOtp: 422時に errors を保持する', () async {
+      late String requestPath;
+      late String requestBody;
+      final service = buildService((request) async {
+        requestPath = request.url.path;
+        requestBody = request.body;
+        return http.Response(
+          jsonEncode({
+            'message': 'validation failed',
+            'errors': {
+              'otp': ['invalid otp'],
+            },
+          }),
+          422,
+        );
+      });
+
+      final result = await service.verifyRegistrationOtp(
+        email: ' new-user@example.com ',
+        otp: '123456',
+      );
+      expect(result.statusCode, 422);
+      expect(result.status, RegistrationApiStatus.unprocessableEntity);
+      expect(result.isValidationError, isTrue);
+      expect(result.errors?['otp'], ['invalid otp']);
+      expect(requestPath, '/api/auth/register/otp/verify');
+      final decoded = jsonDecode(requestBody) as Map<String, dynamic>;
+      expect(decoded['email'], 'new-user@example.com');
+      expect(decoded['otp'], '123456');
+    });
+
+    test('completeRegistration: 201成功と name trim を確認できる', () async {
+      late String requestPath;
+      late String requestBody;
+      final service = buildService((request) async {
+        requestPath = request.url.path;
+        requestBody = request.body;
+        return http.Response(
+          jsonEncode({
+            'message': 'registration completed',
+            'data': {'user_id': 10},
+          }),
+          201,
+        );
+      });
+
+      final result = await service.completeRegistration(
+        registrationToken: 'token-123',
+        name: '  Test User  ',
+        password: 'Password123!',
+      );
+      expect(result.statusCode, 201);
+      expect(result.status, RegistrationApiStatus.created);
+      expect(result.isSuccess, isTrue);
+      expect(result.data?['user_id'], 10);
+      expect(requestPath, '/api/auth/register/complete');
+      final decoded = jsonDecode(requestBody) as Map<String, dynamic>;
+      expect(decoded['registration_token'], 'token-123');
+      expect(decoded['name'], 'Test User');
+      expect(decoded['password'], 'Password123!');
+    });
+
+    test('completeRegistration: 409/429/500を正規化できる', () async {
+      final cases = <int, RegistrationApiStatus>{
+        409: RegistrationApiStatus.conflict,
+        429: RegistrationApiStatus.tooManyRequests,
+        500: RegistrationApiStatus.unknownError,
+      };
+
+      for (final entry in cases.entries) {
+        final service = buildService((request) async {
+          expect(request.url.path, '/api/auth/register/complete');
+          return http.Response(
+            jsonEncode({'message': 'status-${entry.key}'}),
+            entry.key,
+          );
+        });
+
+        final result = await service.completeRegistration(
+          registrationToken: 'token-123',
+          name: 'Tester',
+          password: 'Password123!',
+        );
+        expect(result.statusCode, entry.key);
+        expect(result.status, entry.value);
+        expect(result.message, 'status-${entry.key}');
+      }
     });
   });
 }

--- a/test/services/api_service_test.dart
+++ b/test/services/api_service_test.dart
@@ -163,6 +163,62 @@ void main() {
       expect(result.message, 'ワンタイムパスワードの送信に失敗しました。');
     });
 
+    test('sendRegistrationOtp: 空文字はHTTPリクエストせず422を返す', () async {
+      final service = buildService((_) async {
+        fail('HTTP request should not be made for empty email');
+      });
+
+      final result = await service.sendRegistrationOtp('');
+      expect(result.statusCode, 422);
+      expect(result.status, RegistrationApiStatus.unprocessableEntity);
+      expect(result.isValidationError, isTrue);
+    });
+
+    test('sendRegistrationOtp: 不正形式メールはHTTPリクエストせず422を返す', () async {
+      final service = buildService((_) async {
+        fail('HTTP request should not be made for invalid email');
+      });
+
+      final result = await service.sendRegistrationOtp('not-an-email');
+      expect(result.statusCode, 422);
+      expect(result.status, RegistrationApiStatus.unprocessableEntity);
+      expect(result.isValidationError, isTrue);
+    });
+
+    test('sendRegistrationOtp: 長すぎるメールはHTTPリクエストせず422を返す', () async {
+      final service = buildService((_) async {
+        fail('HTTP request should not be made for very long email');
+      });
+      final longEmail = '${List.filled(1001, 'a').join()}@example.com';
+
+      final result = await service.sendRegistrationOtp(longEmail);
+      expect(result.statusCode, 422);
+      expect(result.status, RegistrationApiStatus.unprocessableEntity);
+      expect(result.isValidationError, isTrue);
+    });
+
+    test('verifyRegistrationOtp: 200成功を正規化できる', () async {
+      final service = buildService((request) async {
+        expect(request.url.path, '/api/auth/register/otp/verify');
+        return http.Response(
+          jsonEncode({
+            'message': 'verified',
+            'data': {'registration_token': 'reg-token-123'},
+          }),
+          200,
+        );
+      });
+
+      final result = await service.verifyRegistrationOtp(
+        email: 'new-user@example.com',
+        otp: '123456',
+      );
+      expect(result.statusCode, 200);
+      expect(result.status, RegistrationApiStatus.success);
+      expect(result.data?['registration_token'], 'reg-token-123');
+      expect(result.isValidationError, isFalse);
+    });
+
     test('verifyRegistrationOtp: 422時に errors を保持する', () async {
       late String requestPath;
       late String requestBody;
@@ -192,6 +248,45 @@ void main() {
       final decoded = jsonDecode(requestBody) as Map<String, dynamic>;
       expect(decoded['email'], 'new-user@example.com');
       expect(decoded['otp'], '123456');
+    });
+
+    test('verifyRegistrationOtp: 409/429/500を正規化できる', () async {
+      final cases = <int, RegistrationApiStatus>{
+        409: RegistrationApiStatus.conflict,
+        429: RegistrationApiStatus.tooManyRequests,
+        500: RegistrationApiStatus.unknownError,
+      };
+
+      for (final entry in cases.entries) {
+        final service = buildService((_) async {
+          return http.Response(
+            jsonEncode({'message': 'status-${entry.key}'}),
+            entry.key,
+          );
+        });
+
+        final result = await service.verifyRegistrationOtp(
+          email: 'new-user@example.com',
+          otp: '123456',
+        );
+        expect(result.statusCode, entry.key);
+        expect(result.status, entry.value);
+        expect(result.isValidationError, isFalse);
+      }
+    });
+
+    test('verifyRegistrationOtp: ネットワーク例外は networkError にマッピングされる', () async {
+      final service = buildService((_) async {
+        throw Exception('network down');
+      });
+
+      final result = await service.verifyRegistrationOtp(
+        email: 'new-user@example.com',
+        otp: '123456',
+      );
+      expect(result.statusCode, 0);
+      expect(result.status, RegistrationApiStatus.networkError);
+      expect(result.isValidationError, isFalse);
     });
 
     test('completeRegistration: 201成功と name trim を確認できる', () async {
@@ -250,6 +345,44 @@ void main() {
         expect(result.status, entry.value);
         expect(result.message, 'status-${entry.key}');
       }
+    });
+
+    test('completeRegistration: 422時に errors を保持する', () async {
+      final service = buildService((_) async {
+        return http.Response(
+          jsonEncode({
+            'message': 'validation failed',
+            'errors': {
+              'name': ['name is invalid'],
+            },
+          }),
+          422,
+        );
+      });
+
+      final result = await service.completeRegistration(
+        registrationToken: 'token-123',
+        name: 'Tester',
+        password: 'Password123!',
+      );
+      expect(result.statusCode, 422);
+      expect(result.status, RegistrationApiStatus.unprocessableEntity);
+      expect(result.isValidationError, isTrue);
+      expect(result.errors?['name'], ['name is invalid']);
+    });
+
+    test('completeRegistration: ネットワーク例外は networkError にマッピングされる', () async {
+      final service = buildService((_) async {
+        throw Exception('network down');
+      });
+
+      final result = await service.completeRegistration(
+        registrationToken: 'token-123',
+        name: 'Tester',
+        password: 'Password123!',
+      );
+      expect(result.statusCode, 0);
+      expect(result.status, RegistrationApiStatus.networkError);
     });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユーザー登録フォームにクライアント側のメール検証を追加。無効なメールはリクエスト前に422で返され、即時エラー表示されます。
  * 登録フローで入力値の自動トリミング（メール・氏名）を行うようになりました。

* **不具合修正**
  * ネットワーク例外や各種HTTPステータスを一貫したエラー状態に正規化する処理を改善しました。

* **テスト**
  * 登録APIまわりの振る舞いを検証するテスト群を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->